### PR TITLE
Tweak cards and header

### DIFF
--- a/src/components/ActivityCard/styles.ts
+++ b/src/components/ActivityCard/styles.ts
@@ -29,5 +29,5 @@ export const Description = styled.p`
 `;
 
 export const ActivityImage = styled(Image)`
-  border-radius: ${spacing[4]};
+  border-radius: ${spacing[3]};
 `;

--- a/src/components/ActivityList/index.tsx
+++ b/src/components/ActivityList/index.tsx
@@ -21,7 +21,7 @@ const ActivityList = ({ activities }: Props): JSX.Element => {
   return (
     <Container>
       <ResultsSummary borderBottom={borderBottom}>
-        <h4>{activities?.length} category-name activities</h4>
+        <h4>{activities?.length} activities</h4>
         <FilterTEMP>Filter</FilterTEMP>
       </ResultsSummary>
 

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -1,7 +1,5 @@
 import { HeaderContainer, Menu, Shortcuts } from './styles';
-import theme from '../../styles/theme';
 import HeartButton from '../uiComponents/heartButton';
-import Bars from '../Icon/genericIcons/Bars';
 
 const Header = (): JSX.Element => (
   <HeaderContainer>
@@ -9,7 +7,6 @@ const Header = (): JSX.Element => (
     <Menu>Categories list TODO</Menu>
     <Shortcuts>
       <HeartButton />
-      <Bars colour={theme.colors.primary['5']} />
     </Shortcuts>
   </HeaderContainer>
 );

--- a/src/components/Header/styles.ts
+++ b/src/components/Header/styles.ts
@@ -2,12 +2,10 @@ import styled from 'styled-components';
 import { spacing, colors } from '../../styles/theme';
 
 export const HeaderContainer = styled.div`
-  display: flex;
-  box-sizing: border-box;
-  flex-direction: row;
-  background-color: white;
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
   padding: 0 ${spacing[6]};
-  justify-content: space-between;
+  justify-content: center;
   align-items: center;
   box-shadow: ${colors.neutral[10]} 0px 1px 1px;
   z-index: 1;
@@ -19,5 +17,6 @@ export const Menu = styled.div`
 
 export const Shortcuts = styled.div`
   display: flex;
+  justify-content: flex-end;
   align-items: center;
 `;

--- a/src/components/uiComponents/heartButton/styles.ts
+++ b/src/components/uiComponents/heartButton/styles.ts
@@ -1,5 +1,5 @@
 import styled from 'styled-components';
-import theme, {spacing} from '../../../styles/theme';
+import theme, { spacing } from '../../../styles/theme';
 
 export const Button = styled.button.attrs({ type: 'button' })`
   display: flex;
@@ -8,9 +8,4 @@ export const Button = styled.button.attrs({ type: 'button' })`
   padding: ${spacing['2']};
   border-radius: 100%;
   color: ${theme.colors.supporting.red['7']};
-  
-  svg {
-    width: ${spacing['3']};
-    height: ${spacing['3']};
-  }
 `;


### PR DESCRIPTION
- Fixed issue where central header element would have been off-centre if either left or right element was longer
- Removed menu icon on header for now (no menu likely soon?)
- Increased size of heart icon in header (12px > 16px)
- Simplified activity results summary wording to match AirBnB
- Reduced border radius on cards to match AirBnB