### PR TITLE
Add transparent mode for mobile activity header

### DIFF
--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -2,16 +2,26 @@ import Link from 'next/link';
 import { useState } from 'react';
 import useBackUrl from '../../hooks/useBackUrl';
 import Icon from '../Icon';
-import { BackButtonContainer, HeaderContainer, HeaderContent, Menu, ShareButtonContainer, Shortcuts } from './styles';
+import {
+  BackButtonContainer,
+  HeaderContainer,
+  HeaderContent,
+  LogoContainer,
+  Menu,
+  ShareButtonContainer,
+  Shortcuts,
+} from './styles';
 // import HeartCircleButton from '../uiComponents/HeartCircleButton';
 
 interface Props {
   widthConstrained: boolean;
+  transparentVariant?: boolean;
 }
 
-const Header = ({ widthConstrained }: Props): JSX.Element => {
+const Header = ({ widthConstrained, transparentVariant }: Props): JSX.Element => {
   const [copiedToClipboard, setCopiedToClipboard] = useState(false);
   const backUrl = useBackUrl();
+  const transparentMode = transparentVariant && backUrl ? true : false;
 
   const share = () => {
     const currentUrl = window.location.href;
@@ -26,25 +36,23 @@ const Header = ({ widthConstrained }: Props): JSX.Element => {
   };
 
   return (
-    <HeaderContainer>
+    <HeaderContainer transparentMode={transparentMode}>
       <HeaderContent widthConstrained={widthConstrained}>
         {backUrl && (
           <Link href={backUrl} passHref>
-            <BackButtonContainer>
+            <BackButtonContainer transparentMode={transparentMode}>
               <Icon icon="LeftArrow" />
             </BackButtonContainer>
           </Link>
         )}
-        <h2>Logo</h2>
+        <LogoContainer transparentMode={transparentMode}>
+          <h2>Logo</h2>
+        </LogoContainer>
         {!backUrl && <Menu>Categories</Menu>}
         <Shortcuts>
-          {copiedToClipboard ? (
-            <h4>Copied link</h4>
-          ) : (
-            <ShareButtonContainer onClick={share}>
-              <Icon icon="Share" />
-            </ShareButtonContainer>
-          )}
+          <ShareButtonContainer onClick={share} transparentMode={transparentMode}>
+            {copiedToClipboard ? <h4>Copied link</h4> : <Icon icon="Share" />}
+          </ShareButtonContainer>
           {/* <HeartCircleButton /> */}
         </Shortcuts>
       </HeaderContent>

--- a/src/components/Header/styles.ts
+++ b/src/components/Header/styles.ts
@@ -4,15 +4,24 @@ import { spacing, colors, shadows } from '../../styles/theme';
 
 export const HeaderHeight = `${spacing[8]}`;
 
-export const HeaderContainer = styled.div`
-  position: sticky;
+interface HeaderElementProps {
+  transparentMode: boolean;
+}
+
+export const HeaderContainer = styled.div<HeaderElementProps>`
+  position: ${({ transparentMode }) => (transparentMode ? 'absolute' : 'sticky')};
   top: 0;
   z-index: 1;
   box-sizing: border-box;
   width: 100vw;
   height: ${HeaderHeight};
-  background-color: ${colors.supporting.grey[10]};
-  box-shadow: ${shadows.divider};
+  box-shadow: ${({ transparentMode }) => (transparentMode ? 'none' : shadows.divider)};
+  background-color: ${({ transparentMode }) => (transparentMode ? 'transparent' : colors.supporting.grey[10])};
+
+  @media ${device.mobileXL} {
+    position: sticky;
+    background-color: ${colors.supporting.grey[10]};
+  }
 `;
 
 export const HeaderContent = styled.div<{ widthConstrained: boolean }>`
@@ -40,14 +49,30 @@ export const Shortcuts = styled.div`
   align-items: center;
 `;
 
-export const BackButtonContainer = styled.div`
+const ButtonContainer = styled.div<HeaderElementProps>`
   padding: ${spacing[2]};
-  margin-left: -${spacing[1]};
-  width: fit-content;
+  border-radius: ${spacing[10]};
   cursor: pointer;
+  background-color: ${({ transparentMode }) => (transparentMode ? 'rgba(255, 255, 255, 0.8)' : 'none')};
+  backdrop-filter: ${({ transparentMode }) => (transparentMode ? `blur(${spacing[1]})` : 'none')};
+
+  @media ${device.mobileXL} {
+    background-color: none;
+    backdrop-filter: none;
+  }
 `;
 
-export const ShareButtonContainer = styled.div`
-  padding: ${spacing[2]};
-  cursor: pointer;
+export const BackButtonContainer = styled(ButtonContainer)`
+  margin-left: -${spacing[1]};
+  width: fit-content;
+`;
+
+export const ShareButtonContainer = styled(ButtonContainer)``;
+
+export const LogoContainer = styled.div<HeaderElementProps>`
+  opacity: ${({ transparentMode }) => (transparentMode ? 0 : 1)};
+
+  @media ${device.mobileXL} {
+    opacity: 1;
+  }
 `;

--- a/src/components/Header/styles.ts
+++ b/src/components/Header/styles.ts
@@ -19,6 +19,7 @@ export const HeaderContainer = styled.div<HeaderElementProps>`
   background-color: ${({ transparentMode }) => (transparentMode ? 'transparent' : colors.supporting.grey[10])};
 
   @media ${device.mobileXL} {
+    box-shadow: ${shadows.divider};
     position: sticky;
     background-color: ${colors.supporting.grey[10]};
   }

--- a/src/components/MiniMap/index.tsx
+++ b/src/components/MiniMap/index.tsx
@@ -9,7 +9,7 @@ interface Props {
   initialViewState: Partial<ViewState>;
 }
 
-const MapContainer = ({ location, initialViewState }: Props): JSX.Element => (
+const MiniMap = ({ location, initialViewState }: Props): JSX.Element => (
   <Container>
     <Map
       style={{ borderRadius: spacing[3] }}
@@ -22,4 +22,4 @@ const MapContainer = ({ location, initialViewState }: Props): JSX.Element => (
   </Container>
 );
 
-export default MapContainer;
+export default MiniMap;

--- a/src/pages/activity/[activityId].tsx
+++ b/src/pages/activity/[activityId].tsx
@@ -83,7 +83,7 @@ const ActivityPage: NextPage<Props> = ({ activity, error }) => {
 
   return (
     <>
-      <Header widthConstrained={true} />
+      <Header widthConstrained={true} transparentVariant={true} />
       <MobileOnly>
         <ActivityImage {...activityImageProps} width={deviceWidthPx.mobileXL} height={spacing[13]} />
       </MobileOnly>

--- a/src/pages/activity/[activityId].tsx
+++ b/src/pages/activity/[activityId].tsx
@@ -233,7 +233,7 @@ const ActivityPage: NextPage<Props> = ({ activity, error }) => {
 
                 <MiniMap
                   location={activity.location}
-                  initialViewState={{ longitude: activity.location.long, latitude: activity.location.lat, zoom: 11 }}
+                  initialViewState={{ longitude: activity.location.long, latitude: activity.location.lat, zoom: 13 }}
                 />
               </DetailsSection>
 


### PR DESCRIPTION
- On activity page only
- If mobile size, and if `?backUrl=...` is present in the URL (come from a previous page, not fresh in from a shared URL), then the header is reduced to a two-button overlay
- If `?backUrl=...` is not present in the URL, or if tablet/desktop size, the usual header is displayed.

## Transparent mode

<img width="374" alt="Screenshot 2022-09-18 at 17 00 59" src="https://user-images.githubusercontent.com/20062773/190916610-ceebb600-a6fe-4937-a911-e7ecabb68256.png">

## Normal mode

<img width="374" alt="Screenshot 2022-09-18 at 17 01 18" src="https://user-images.githubusercontent.com/20062773/190916611-51f6425d-5289-443e-be19-aef50241b200.png">

